### PR TITLE
GetBuffer Parsing improvements

### DIFF
--- a/MAPIInspector/Source/MAPIInspector.cs
+++ b/MAPIInspector/Source/MAPIInspector.cs
@@ -1350,7 +1350,7 @@
                     bytes = bytesForHexView;
                 }
             }
-            else if ((RopIdType)ropID == RopIdType.RopFastTransferDestinationPutBuffer || (RopIdType)ropID == RopIdType.RopFastTransferDestinationPutBufferExtended)
+            else if (ropID == RopIdType.RopFastTransferDestinationPutBuffer || ropID == RopIdType.RopFastTransferDestinationPutBufferExtended)
             {
                 if (this.requestDic.ContainsKey(thisSessionID))
                 {
@@ -1393,7 +1393,7 @@
                     Session currentSession = AllSessions[1];
                     int currentSessionID = currentSession.id;
 
-                    if ((RopIdType)ropID == RopIdType.RopFastTransferDestinationPutBuffer)
+                    if (ropID == RopIdType.RopFastTransferDestinationPutBuffer)
                     {
                         int sessionPutContextCount = HandleWithSessionPutContextInformation.Count;
 

--- a/MAPIInspector/Source/MAPIInspector.cs
+++ b/MAPIInspector/Source/MAPIInspector.cs
@@ -1227,7 +1227,7 @@
         /// <param name="parameters">The handle information</param>
         /// <param name="bytes">The output bytes returned</param>
         /// <returns>The parsed result for current session</returns>
-        public object Partial(ushort ropID, uint parameters, out byte[] bytes)
+        public object Partial(RopIdType ropID, uint parameters, out byte[] bytes)
         {
             byte[] bytesForHexView = new byte[0];
             object obj = new object();
@@ -1235,7 +1235,7 @@
             Session thisSession = MAPIInspector.ParsingSession;
             int thisSessionID = thisSession.id;
 
-            if ((RopIdType)ropID == RopIdType.RopFastTransferSourceGetBuffer)
+            if (ropID == RopIdType.RopFastTransferSourceGetBuffer)
             {
                 if (this.responseDic.ContainsKey(thisSessionID))
                 {
@@ -2111,9 +2111,9 @@
                 this.HandleContextInformation(missingException.RopID, out objectOut, out bytes, missingException.Parameters);
                 return objectOut;
             }
-            catch (MissingPartialInformationException missingPartailException)
+            catch (MissingPartialInformationException missingPartialException)
             {
-                objectOut = this.Partial(missingPartailException.RopID, missingPartailException.Parameter, out bytes);
+                objectOut = this.Partial(missingPartialException.RopID, missingPartialException.Parameter, out bytes);
                 return objectOut;
             }
             catch (Exception ex)

--- a/MAPIInspector/Source/MAPIInspector.cs
+++ b/MAPIInspector/Source/MAPIInspector.cs
@@ -1337,6 +1337,7 @@
                         }
 
                         currentSession = AllSessions[Convert.ToInt32(currentSession["Number"]) + 1];
+                        if (currentSessionID == currentSession.id) break;
                         currentSessionID = currentSession.id;
                     }
 

--- a/MAPIInspector/Source/Parsers/BaseStructure.cs
+++ b/MAPIInspector/Source/Parsers/BaseStructure.cs
@@ -379,8 +379,7 @@
                         // the size of underlying type of enum. 
                         Type fieldType = type;
 
-                        // TODO: display decimal value to hex one
-                        TreeNode tn = new TreeNode(string.Format("{0}:{1}", info[i].Name, info[i].GetValue(obj).ToString()));
+                        TreeNode tn = new TreeNode(string.Format("{0}:{1}", info[i].Name, EnumToString(info[i].GetValue(obj))));
                         res.Nodes.Add(tn);
 
                         if (type.Name == "String")
@@ -451,20 +450,20 @@
                                 else
                                 {
                                     // Array type just display the first 30 values if the array length is more than 30.
-                                    int dispalylength = 30;
+                                    int displayLength = 30;
                                     result.Append("[");
 
                                     foreach (var ar in arr)
                                     {
                                         result.Append(ar.ToString() + ",");
 
-                                        if (dispalylength <= 1)
+                                        if (displayLength <= 1)
                                         {
                                             result.Insert(result.Length - 1, "...");
                                             break;
                                         }
 
-                                        dispalylength--;
+                                        displayLength--;
                                     }
 
                                     result.Remove(result.Length - 1, 1);
@@ -1027,6 +1026,23 @@
             }
 
             return chars[0];
+        }
+
+        /// <summary>
+        /// Converts a simple (non-flag) enum to string. If the value is not present in the underlying enum, converts to a hex string.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        private static string EnumToString(object obj)
+        {
+            if (Enum.IsDefined(obj.GetType(), obj))
+            {
+                return obj.ToString();
+            }
+            else
+            {
+                return $"0x{Convert.ToUInt64(obj):X}";
+            }
         }
 
         /// <summary>

--- a/MAPIInspector/Source/Parsers/MSOXCFXICS.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCFXICS.cs
@@ -4428,7 +4428,7 @@
         /// <summary>
         /// The propType.
         /// </summary>
-        public ushort? PropType;
+        public PropertyDataType? PropType;
 
         /// <summary>
         /// The PropInfo.
@@ -4515,7 +4515,7 @@
                 (MapiInspector.MAPIInspector.IsGet == true && (MapiInspector.MAPIInspector.PartialGetType == 0 || (MapiInspector.MAPIInspector.PartialGetType != 0 && !(MapiInspector.MAPIInspector.PartialGetServerUrl == MapiInspector.MAPIInspector.ParsingSession.RequestHeaders.RequestPath && MapiInspector.MAPIInspector.PartialGetProcessName == MapiInspector.MAPIInspector.ParsingSession.LocalProcess && MapiInspector.MAPIInspector.PartialGetClientInfo == MapiInspector.MAPIInspector.ParsingSession.RequestHeaders["X-ClientInfo"])))) ||
                 (MapiInspector.MAPIInspector.IsPutExtend == true && (MapiInspector.MAPIInspector.PartialPutExtendType == 0 || (MapiInspector.MAPIInspector.PartialPutType != 0 && !(MapiInspector.MAPIInspector.PartialPutExtendServerUrl == MapiInspector.MAPIInspector.ParsingSession.RequestHeaders.RequestPath && MapiInspector.MAPIInspector.PartialPutExtendProcessName == MapiInspector.MAPIInspector.ParsingSession.LocalProcess && MapiInspector.MAPIInspector.PartialPutExtendClientInfo == MapiInspector.MAPIInspector.ParsingSession.RequestHeaders["X-ClientInfo"])))))
             {
-                this.PropType = stream.ReadUInt16();
+                this.PropType = (PropertyDataType)stream.ReadUInt16();
                 this.PropInfo = PropInfo.ParseFrom(stream) as PropInfo;
             }
         }
@@ -5506,7 +5506,7 @@
         /// <summary>
         /// Length value for partial split
         /// </summary>
-        public int Plength;
+        private int Plength;
 
         /// <summary>
         /// Initializes a new instance of the MvPropTypePropValueGetPartial class.
@@ -6163,7 +6163,7 @@
         /// <summary>
         /// Length for partial
         /// </summary>
-        public int Plength;
+        private int Plength;
 
         /// <summary>
         /// Initializes a new instance of the MvPropTypePropValuePutPartial class.
@@ -6823,7 +6823,7 @@
         /// <summary>
         /// Length for partial
         /// </summary>
-        public int Plength;
+        private int Plength;
 
         /// <summary>
         /// Initializes a new instance of the MvPropTypePropValuePutExtendPartial class.

--- a/MAPIInspector/Source/Parsers/MSOXCROPS.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCROPS.cs
@@ -1360,7 +1360,7 @@
                                 {
                                     if (!DecodingContext.PartialInformationReady.ContainsKey((int)destinationParsingSessionID))
                                     {
-                                        throw new MissingPartialInformationException((ushort)currentByte, ropPutbufferHandle);
+                                        throw new MissingPartialInformationException((RopIdType)currentByte, ropPutbufferHandle);
                                     }
                                 }
                                 else
@@ -1410,7 +1410,7 @@
                                 {
                                     if (!DecodingContext.PartialInformationReady.ContainsKey((int)aimsParsingSessionID))
                                     {
-                                        throw new MissingPartialInformationException((ushort)currentByte, ropPutExtendbufferHandle);
+                                        throw new MissingPartialInformationException((RopIdType)currentByte, ropPutExtendbufferHandle);
                                     }
                                 }
                                 else
@@ -2558,7 +2558,7 @@
                                 {
                                     if (!DecodingContext.PartialInformationReady.ContainsKey((int)getParsingSessionID))
                                     {
-                                        throw new MissingPartialInformationException((ushort)currentByte, ropGetbufferHandle);
+                                        throw new MissingPartialInformationException((RopIdType)currentByte, ropGetbufferHandle);
                                     }
                                 }
 
@@ -4395,7 +4395,7 @@
         /// <summary>
         /// The ROP ID needs context information
         /// </summary>
-        public ushort RopID;
+        public RopIdType RopID;
 
         /// <summary>
         /// The source ROP parameters to pass
@@ -4407,7 +4407,7 @@
         /// </summary>
         /// <param name="ropID">ROP id</param>
         /// <param name="parameter">parameters for this missing partial information exception</param>
-        public MissingPartialInformationException(ushort ropID, uint parameter)
+        public MissingPartialInformationException(RopIdType ropID, uint parameter)
         {
             this.RopID = ropID;
             this.Parameter = parameter;


### PR DESCRIPTION
Parse missing enums as hex
Fix typo: dispalyLength
Parse property types with enum
Hide internal PLength var so it doesn't corrupt parsings (we end up off in highlighting)