### PR TITLE
Better default auxiliary blocks

### DIFF
--- a/MAPIInspector/Source/Parsers/MSOXCDATA.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCDATA.cs
@@ -1,5 +1,6 @@
 ﻿namespace MAPIInspector.Parsers
 {
+    using MapiInspector;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -3855,6 +3856,56 @@
         /// TRUE if the value of the object's property is in the DL membership of the specified property value. 
         /// </summary>
         RelationalOperatorMemberOfDL = 0x64
+    }
+
+    /// <summary>
+    /// The AnnotatedBytes class to a byte stream with an alternate version of it (typically ConvertByteArrayToString)
+    /// </summary>
+    public class AnnotatedBytes : BaseStructure
+    {
+        /// <summary>
+        /// Bytes as byte array.
+        /// </summary>
+        public byte[] bytes;
+
+        /// <summary>
+        /// The annotated value
+        /// </summary>
+        public string Annotation;
+
+        //public int StartIndex;
+
+        private int Size;
+
+        /// <summary>
+        /// Initializes a new instance of the MAPIString class without parameters.
+        /// </summary>
+        public AnnotatedBytes()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Information class with parameters.
+        /// </summary>
+        /// <param name="size">Size of the byte array</param>
+        public AnnotatedBytes(int size)
+        {
+            this.Size = size;
+        }
+
+        /// <summary>
+        /// Parse method
+        /// </summary>
+        /// <param name="s">The stream to parse</param>
+        public override void Parse(Stream s)
+        {
+            base.Parse(s);
+            var offset = (int)s.Position;
+            this.bytes = this.ReadBytes(this.Size);
+            this.Annotation = Utilities.ConvertByteArrayToString(this.bytes);
+        }
+
+        public void SetAnnotation(string annotation) { this.Annotation = annotation; }
     }
 
     /// <summary>

--- a/MAPIInspector/Source/Parsers/MSOXCMAPIHTTP.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCMAPIHTTP.cs
@@ -5066,8 +5066,12 @@
                         }
 
                     default:
-                        this.AuxiliaryBlock = this.ReadBytes((int)this.AUXHEADER.Size - 4);
-                        break;
+                        {
+                            AnnotatedBytes auxiliaryBlock = new AnnotatedBytes(this.AUXHEADER.Size - 4);
+                            auxiliaryBlock.Parse(s);
+                            this.AuxiliaryBlock = auxiliaryBlock;
+                            break;
+                        }
                 }
             }
             else if (this.AUXHEADER.Version == PayloadDataVersion.AUX_VERSION_2)
@@ -5164,13 +5168,19 @@
                         }
 
                     default:
-                        this.AuxiliaryBlock = this.ReadBytes((int)this.AUXHEADER.Size - 4);
-                        break;
+                        {
+                            AnnotatedBytes auxiliaryBlock = new AnnotatedBytes(this.AUXHEADER.Size - 4);
+                            auxiliaryBlock.Parse(s);
+                            this.AuxiliaryBlock = auxiliaryBlock;
+                            break;
+                        }
                 }
             }
             else
             {
-                this.AuxiliaryBlock = this.ReadBytes((int)this.AUXHEADER.Size - 4);
+                AnnotatedBytes auxiliaryBlock = new AnnotatedBytes(this.AUXHEADER.Size - 4);
+                auxiliaryBlock.Parse(s);
+                this.AuxiliaryBlock = auxiliaryBlock;
             }
         }
     }

--- a/MAPIInspector/Source/Utilities.cs
+++ b/MAPIInspector/Source/Utilities.cs
@@ -3,6 +3,7 @@
     using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
+    using System.Text;
 
     /// <summary>
     /// The utilities class for MAPI Inspector.
@@ -16,7 +17,7 @@
         /// <returns>The converted string result</returns>
         public static string ConvertUintToString(uint data)
         {
-            return data.ToString() + " (0x" + data.ToString("X8") + ")"; 
+            return data.ToString() + " (0x" + data.ToString("X8") + ")";
         }
 
         /// <summary>
@@ -26,7 +27,62 @@
         /// <returns>The converted string result</returns>
         public static string ConvertUshortToString(ushort data)
         {
-            return data.ToString() + " (0x" + data.ToString("X4") + ")"; 
+            return data.ToString() + " (0x" + data.ToString("X4") + ")";
+        }
+
+        public static string ConvertByteArrayToString(byte[] bin, uint? limit = null)
+        {
+            if (bin == null || bin.Length == 0) return string.Empty;
+
+            var szText = new StringBuilder();
+            long length = bin.Length;
+            if (limit.HasValue) length = Math.Min(length, limit.Value);
+            for (uint i = 0; i < length; i++)
+            {
+                if (bin[i] <= 0x8)
+                {
+                    szText.Append(".");
+                }
+                else if (bin[i] >= 0xA && bin[i] <= 0x1F)
+                {
+                    szText.Append(".");
+                }
+                else if (bin[i] > 0xff)
+                {
+                    szText.Append(".");
+                }
+                else
+                {
+                    szText.Append((char)bin[i]);
+                }
+            }
+
+            return szText.ToString();
+        }
+
+        // Array type just display the first 30 values if the array length is more than 30.
+        public static string ConvertByteArrayToHexString(byte[] bin, int? limit = 30)
+        {
+            var result = new StringBuilder();
+            int displayLength = limit.HasValue?limit.Value:bin.Length;
+            result.Append("[");
+
+            foreach (var b in bin)
+            {
+                result.Append(b.ToString() + ",");
+
+                if (displayLength <= 1)
+                {
+                    result.Insert(result.Length - 1, "...");
+                    break;
+                }
+
+                displayLength--;
+            }
+
+            result.Remove(result.Length - 1, 1);
+            result.Append("]");
+            return result.ToString();
         }
 
         /// <summary>
@@ -43,11 +99,11 @@
             int i = 0;
             do
             {
-                chunkSize = 0;                
+                chunkSize = 0;
                 while (true)
                 {
                     int b = responseBodyFromFiddler[i];
-                    
+
                     if (b >= 0x30 && b <= 0x39)
                     {
                         b -= 0x30;
@@ -66,14 +122,14 @@
                     }
 
                     chunkSize = (chunkSize * 16) + b;
-                    i++;                    
+                    i++;
                 }
 
                 if (responseBodyFromFiddler[i] != 0x0D || responseBodyFromFiddler[i + 1] != 0x0A)
                 {
                     throw new Exception();
-                }   
-                             
+                }
+
                 i += 2;
                 for (int k = 0; k < chunkSize; k++, i++)
                 {
@@ -85,9 +141,9 @@
                     throw new Exception();
                 }
 
-                i += 2;                
+                i += 2;
             }
-            while (chunkSize > 0);            
+            while (chunkSize > 0);
             return payload.ToArray();
         }
 


### PR DESCRIPTION
Add AnnotatedBytes structure to allow displaying alternate versions of byte arrays, such as converting to a string.
Factored out ConvertByteArrayToHexString for reuse
Added position tag for structures to highlight at the root as well.

Converted default auxiliary blocks to use annotated bytes