### PR TITLE
Invalid cast exception in AddNodesForTree

### DIFF
--- a/MAPIInspector/Source/Parsers/BaseStructure.cs
+++ b/MAPIInspector/Source/Parsers/BaseStructure.cs
@@ -283,7 +283,7 @@
             {
                 var infoString = t.GetFields();
                 var bytes = (byte[])infoString[0].GetValue(obj);
-                var bytesString = Utilities.ConvertByteArrayToHexString(bytes);
+                var bytesString = Utilities.ConvertArrayToHexString(bytes);
                 var annotation = (string)infoString[1].GetValue(obj);
                 var node = new TreeNode($"{infoString[0].Name}:{bytesString}");
 
@@ -463,9 +463,13 @@
                                         result.Append(tempbye.ToString("X2"));
                                     }
                                 }
-                                else
+                                else if (arr.GetType().ToString() == "System.Byte[]")
                                 {
-                                    result.Append(Utilities.ConvertByteArrayToHexString((byte[])arr));
+                                    result.Append(Utilities.ConvertArrayToHexString((byte[])arr));
+                                }
+                                else if (arr.GetType().ToString() == "System.Uint[]")
+                                {
+                                    result.Append(Utilities.ConvertArrayToHexString((uint[])arr));
                                 }
 
                                 TreeNode tn = new TreeNode(string.Format("{0}:{1}", info[i].Name, result.ToString()));
@@ -575,7 +579,7 @@
                             if (fieldName == "RPCHEADEREXT")
                             {
                                 if (((ushort)((RPC_HEADER_EXT)info[i].GetValue(obj)).Flags & 0x0002) == (ushort)RpcHeaderFlags.XorMagic
-                                   || ((ushort)((RPC_HEADER_EXT)info[i].GetValue(obj)).Flags & 0x0001) == (ushort)RpcHeaderFlags.Compressed)
+                                    || ((ushort)((RPC_HEADER_EXT)info[i].GetValue(obj)).Flags & 0x0001) == (ushort)RpcHeaderFlags.Compressed)
                                 {
                                     IsCompressedXOR = true;
                                 }

--- a/MAPIInspector/Source/Utilities.cs
+++ b/MAPIInspector/Source/Utilities.cs
@@ -61,10 +61,10 @@
         }
 
         // Array type just display the first 30 values if the array length is more than 30.
-        public static string ConvertByteArrayToHexString(byte[] bin, int? limit = 30)
+        public static string ConvertArrayToHexString<T>(T[] bin, int? limit = 30)
         {
             var result = new StringBuilder();
-            int displayLength = limit.HasValue?limit.Value:bin.Length;
+            int displayLength = limit.HasValue ? limit.Value : bin.Length;
             result.Append("[");
 
             foreach (var b in bin)


### PR DESCRIPTION
We were converting a uint array into a byte array. Templated ConvertByteArrayToHexString to ConvertArrayToHexString so it can take either, then put in checks to ensure we cast appropriately.