### PR TITLE
Incorrect type/annotation messes up size calculations for highlights.…

### DIFF
--- a/MAPIInspector/Source/Parsers/MSOXORULE.cs
+++ b/MAPIInspector/Source/Parsers/MSOXORULE.cs
@@ -678,7 +678,7 @@
         /// The reserved bit.
         /// </summary>
         [BitAttribute(4)]
-        public int Reservedbits0;
+        public byte Reservedbits0;
 
         /// <summary>
         /// Indicates that the message SHOULD be forwarded as a Short Message Service (SMS) text message. 


### PR DESCRIPTION
… Should have been byte