### PR TITLE
U/sgriffin/depends

### DIFF
--- a/MAPIInspector/Source/MAPIInspector.csproj
+++ b/MAPIInspector/Source/MAPIInspector.csproj
@@ -80,7 +80,8 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Test\MAPIAutomationTest\ExternalReference\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(FiddlerPath)\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/MAPIInspector/Source/MAPIInspector.csproj
+++ b/MAPIInspector/Source/MAPIInspector.csproj
@@ -78,7 +78,7 @@
       <HintPath>$(FiddlerPath)\Fiddler.exe</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(FiddlerPath)\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>

--- a/scripts/machine-setup.ps1
+++ b/scripts/machine-setup.ps1
@@ -19,19 +19,50 @@ Write-Host "Installing .NET Framework 4.6.1 Developer Pack silently..."
 Start-Process -FilePath $DotNetInstallerPath -ArgumentList "/q" -Wait
 Write-Host ".NET Framework 4.6.1 Developer Pack installation completed."
 
-# Fiddler installer (check for the latest version on the Telerik website)
-$FiddlerInstallerUrl = "https://telerik-fiddler.s3.amazonaws.com/fiddler/FiddlerSetup.exe"
+# Fiddler installer (try multiple sources)
+$FiddlerInstallerUrls = @(
+    "https://api.getfiddler.com/fc/latest",
+    "https://downloads.getfiddler.com/fiddler-classic/FiddlerSetup.5.0.20253.3311-latest.exe",
+    "https://telerik-fiddler.s3.amazonaws.com/fiddler/FiddlerSetup.exe"
+)
 $FiddlerInstallerPath = "$env:USERPROFILE\Downloads\FiddlerSetup.exe"
+$FiddlerDownloadSuccess = $false
 
-# Download Fiddler installer
-Write-Host "Downloading Fiddler installer from $FiddlerInstallerUrl..."
-Invoke-WebRequest -Uri $FiddlerInstallerUrl -OutFile $FiddlerInstallerPath
+# Try downloading Fiddler installer from multiple sources
+foreach ($url in $FiddlerInstallerUrls) {
+    try {
+        Write-Host "Attempting to download Fiddler installer from $url..."
+        
+        # Download to a temporary path first, then rename to consistent filename
+        $tempPath = "$env:USERPROFILE\Downloads\FiddlerSetup_temp.exe"
+        Invoke-WebRequest -Uri $url -OutFile $tempPath -ErrorAction Stop
+        
+        if (Test-Path $tempPath) {
+            # Rename to consistent filename
+            if (Test-Path $FiddlerInstallerPath) {
+                Remove-Item $FiddlerInstallerPath -Force
+            }
+            Move-Item $tempPath $FiddlerInstallerPath
+            
+            Write-Host "Fiddler installer downloaded successfully from $url and renamed to $FiddlerInstallerPath."
+            $FiddlerDownloadSuccess = $true
+            break
+        }
+    }
+    catch {
+        Write-Warning "Failed to download from $url`: $($_.Exception.Message)"
+        # Clean up any partial downloads
+        if (Test-Path $tempPath) {
+            Remove-Item $tempPath -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path $FiddlerInstallerPath) {
+            Remove-Item $FiddlerInstallerPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
 
-# Check if the download was successful
-if (Test-Path $FiddlerInstallerPath) {
-    Write-Host "Fiddler installer downloaded successfully to $FiddlerInstallerPath."
-} else {
-    Write-Host "Failed to download Fiddler installer."
+if (!$FiddlerDownloadSuccess) {
+    Write-Host "Failed to download Fiddler installer from any source."
     exit 1
 }
 
@@ -39,3 +70,5 @@ if (Test-Path $FiddlerInstallerPath) {
 Write-Host "Installing Fiddler silently..."
 Start-Process -FilePath $FiddlerInstallerPath -ArgumentList "/S" -Wait
 Write-Host "Fiddler installation completed."
+
+Write-Host "✅ All tools installed successfully"


### PR DESCRIPTION
This pull request focuses on improving the reliability of the Fiddler installer download process in the setup script and updates the Newtonsoft.Json dependency in the project file. The main changes include adding fallback URLs for downloading Fiddler and upgrading the Newtonsoft.Json library version.

**Setup script improvements:**

* The Fiddler installer download logic in `scripts/machine-setup.ps1` now tries multiple sources in sequence, improving robustness in case one source is unavailable. It handles errors gracefully, cleans up partial downloads, and confirms success before proceeding.

**Dependency updates:**

* The Newtonsoft.Json reference in `MAPIInspector/Source/MAPIInspector.csproj` is updated from version 6.0.0.0 to 13.0.0.0, ensuring the project uses a more recent, secure, and feature-rich version of the library.