### PR TITLE
Better parsing of RopFastTransferSourceGetBufferResponse errors

### DIFF
--- a/MAPIInspector/Source/BlockParser/BlockException.cs
+++ b/MAPIInspector/Source/BlockParser/BlockException.cs
@@ -2,9 +2,10 @@
 
 namespace BlockParser
 {
-    public class BlockException : Block
+    public class BlockException : BlockInteresting
     {
-        public static readonly Color BackColor = Color.LightPink;
+        public override Color BackColor => Color.LightPink;
+        public override string InterestingLabel => "Exceptions found in this block";
 
         public static BlockException Create(string message, System.Exception ex, long offset)
         {

--- a/MAPIInspector/Source/BlockParser/BlockInteresting.cs
+++ b/MAPIInspector/Source/BlockParser/BlockInteresting.cs
@@ -1,0 +1,13 @@
+﻿using System.Drawing;
+
+namespace BlockParser
+{
+    /// <summary>
+    /// Represents an interesting block of data.
+    /// </summary>
+    public abstract class BlockInteresting : Block
+    {
+        public virtual Color BackColor => Color.PaleVioletRed;
+        public virtual string InterestingLabel => "Interesting block";
+    }
+}

--- a/MAPIInspector/Source/BlockParser/BlockJunk.cs
+++ b/MAPIInspector/Source/BlockParser/BlockJunk.cs
@@ -2,9 +2,10 @@
 
 namespace BlockParser
 {
-    public class BlockJunk : Block
+    public class BlockJunk : BlockInteresting
     {
-        public static readonly Color BackColor = Color.Coral;
+        public override Color BackColor => Color.Coral;
+        public override string InterestingLabel => "Exceptions found in this block";
 
         string Label;
         BlockBytes junkData;

--- a/MAPIInspector/Source/MAPIInspector.csproj
+++ b/MAPIInspector/Source/MAPIInspector.csproj
@@ -101,6 +101,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BlockParser\BlockInteresting.cs" />
     <Compile Include="ByteArrayConverter.cs" />
     <Compile Include="MAPIControl.Events.cs">
       <SubType>UserControl</SubType>

--- a/MAPIInspector/Source/Parsers/BaseStructure.cs
+++ b/MAPIInspector/Source/Parsers/BaseStructure.cs
@@ -27,22 +27,12 @@ namespace MAPIInspector.Parsers
         public static TreeNode AddBlock(Block block, bool debug)
         {
             var node = AddBlock(block, 0, debug);
-            if (HasBlock<BlockException>(node))
+            var interestingBlock = FindInterestingBlock(node);
+            if (interestingBlock != null)
             {
-                var exNode = new TreeNode("Exceptions found in this block")
+                var exNode = new TreeNode(interestingBlock.InterestingLabel)
                 {
-                    BackColor = BlockException.BackColor,
-                    Tag = "ignore"
-                };
-                exNode.Nodes.Add(node);
-                return exNode;
-            }
-
-            if (HasBlock<BlockJunk>(node))
-            {
-                var exNode = new TreeNode("Unparsed data found in this block")
-                {
-                    BackColor = BlockJunk.BackColor,
+                    BackColor = interestingBlock.BackColor,
                     Tag = "ignore"
                 };
                 exNode.Nodes.Add(node);
@@ -156,8 +146,7 @@ namespace MAPIInspector.Parsers
                 }
             }
 
-            if (block is BlockException) ColorNodes(node, BlockException.BackColor);
-            if (block is BlockJunk) ColorNodes(node, BlockJunk.BackColor);
+            if (block is BlockInteresting interestingBlock) ColorNodes(node, interestingBlock.BackColor);
 
             return node;
         }
@@ -210,23 +199,24 @@ namespace MAPIInspector.Parsers
             return node;
         }
 
-        private static bool HasBlock<T>(TreeNode node) where T : Block
+        private static BlockInteresting FindInterestingBlock(TreeNode node)
         {
             var pos = node.Tag as Position;
-            if (pos?.SourceBlock is T)
+            if (pos?.SourceBlock is BlockInteresting interestingBlock)
             {
-                return true;
+                return interestingBlock;
             }
 
             foreach (TreeNode child in node.Nodes)
             {
-                if (HasBlock<T>(child))
+                var foundBlock = FindInterestingBlock(child);
+                if (foundBlock != null)
                 {
-                    return true;
+                    return foundBlock;
                 }
             }
 
-            return false;
+            return null;
         }
     }
 }

--- a/MAPIInspector/Source/Parsers/MSOXCFXICS/rops/RopFastTransferSourceGetBufferResponse.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCFXICS/rops/RopFastTransferSourceGetBufferResponse.cs
@@ -67,15 +67,14 @@ namespace MAPIInspector.Parsers
             RopId = ParseT<RopIdType>();
             InputHandleIndex = ParseT<byte>();
             ReturnValue = ParseT<ErrorCodes>();
+            TransferStatus = ParseT<TransferStatus>();
+            InProgressCount = ParseT<ushort>();
+            TotalStepCount = ParseT<ushort>();
+            Reserved = ParseT<byte>();
+            TransferBufferSize = ParseT<ushort>();
 
             if (ReturnValue == ErrorCodes.Success)
             {
-                TransferStatus = ParseT<TransferStatus>();
-                InProgressCount = ParseT<ushort>();
-                TotalStepCount = ParseT<ushort>();
-                Reserved = ParseT<byte>();
-                TransferBufferSize = ParseT<ushort>();
-
                 parser.PushCap(TransferBufferSize);
 
                 var transferBufferList = new List<Block>();

--- a/MAPIInspector/Source/Parsers/MSOXCMAPIHTTP/auxiliary/AUX_EXCEPTION_TRACE.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCMAPIHTTP/auxiliary/AUX_EXCEPTION_TRACE.cs
@@ -1,13 +1,17 @@
 using BlockParser;
 using System.Collections.Generic;
+using System.Drawing;
 
 namespace MAPIInspector.Parsers
 {
     /// <summary>
     /// A class indicates the AUX_TYPE_EXCEPTION_TRACE Auxiliary Block Structure
     /// </summary>
-    public class AUX_EXCEPTION_TRACE : Block
+    public class AUX_EXCEPTION_TRACE : BlockInteresting
     {
+        public override Color BackColor => Color.Salmon;
+        public override string InterestingLabel => "Aux Exception Trace found in this block";
+
         /// <summary>
         /// A flag that indicates that the server combines capabilities on a single endpoint.
         /// </summary>


### PR DESCRIPTION
unified interesting block concept for junk/exceptions
Made aux error trace interesting
This pull request refactors how "interesting" blocks (such as exceptions, junk data, and special auxiliary traces) are represented and handled in the codebase. The main improvement is the introduction of an abstract `BlockInteresting` class, which unifies the way these blocks specify their background color and descriptive label. This change simplifies the logic in the parsing and UI code, making it easier to add new types of interesting blocks in the future.

**Refactoring and abstraction of interesting blocks:**

* Introduced a new abstract class `BlockInteresting` in `BlockInteresting.cs`, providing virtual properties for `BackColor` and `InterestingLabel` to standardize how interesting blocks are identified and displayed.
* Updated `BlockException`, `BlockJunk`, and `AUX_EXCEPTION_TRACE` to inherit from `BlockInteresting` instead of directly from `Block`, and to override the `BackColor` and `InterestingLabel` properties as appropriate. [[1]](diffhunk://#diff-cae3354a15186879999472e4e1ce0ae716989af70beff95af1f8c88b04e777b1L5-R8) [[2]](diffhunk://#diff-7d17bdb5fa8dbb2ebb081518b1bb26ab03cb8f81ead2df757b78a3a211e16db1L5-R8) [[3]](diffhunk://#diff-87511afaab9a531029b2ce46c624ed1d4ce07a0679e7a08485d469b454cd9b57R3-R14)

**UI and logic simplification:**

* Refactored `BaseStructure` methods to use the new `BlockInteresting` abstraction: replaced type-specific checks for exception and junk blocks with a unified search for any `BlockInteresting` instance, and used their properties for UI rendering. [[1]](diffhunk://#diff-de1d7a493a34e788f94704c2bf91618e046f68503cbab98cfabe8ec403e87411L30-R35) [[2]](diffhunk://#diff-de1d7a493a34e788f94704c2bf91618e046f68503cbab98cfabe8ec403e87411L159-R149) [[3]](diffhunk://#diff-de1d7a493a34e788f94704c2bf91618e046f68503cbab98cfabe8ec403e87411L213-R219)

**Project structure:**

* Added `BlockInteresting.cs` to the project file so it is included in the build.

**Minor parsing fix:**

* Fixed the parsing logic in `RopFastTransferSourceGetBufferResponse.cs` to ensure the transfer buffer is only parsed when the return value indicates success.