### PR TITLE
U/sgriffin/roptransport

### DIFF
--- a/MAPIInspector/Source/BlockParser/BlockJunk.cs
+++ b/MAPIInspector/Source/BlockParser/BlockJunk.cs
@@ -5,7 +5,7 @@ namespace BlockParser
     public class BlockJunk : BlockInteresting
     {
         public override Color BackColor => Color.Coral;
-        public override string InterestingLabel => "Exceptions found in this block";
+        public override string InterestingLabel => "Extra data found in this block";
 
         string Label;
         BlockBytes junkData;

--- a/MAPIInspector/Source/MAPIControl.Events.cs
+++ b/MAPIInspector/Source/MAPIControl.Events.cs
@@ -314,18 +314,20 @@ namespace MapiInspector
             if (string.IsNullOrEmpty(searchText) || searchText == SearchDefaultText) return;
 
             FiddlerApplication.UI.SetStatusText($"Searching for {searchText}");
+            var includeRoot = false; // Don't include the currently selected node for a seach
             var startNode = mapiTreeView?.SelectedNode;
             if (startNode == null && mapiTreeView?.Nodes.Count > 0)
             {
                 startNode = mapiTreeView.Nodes[0];
+                includeRoot = true; // But if no node was selected, incude whatever node we start from
             }
 
             if (startNode != null)
             {
                 var nodes = mapiTreeView.Nodes;
                 TreeNode foundNode = searchUp
-                    ? FindPrevNode(nodes, startNode, searchText, !searchFrames, false)
-                    : FindNextNode(nodes, startNode, searchText, !searchFrames, false);
+                    ? FindPrevNode(nodes, startNode, searchText, !searchFrames, includeRoot)
+                    : FindNextNode(nodes, startNode, searchText, !searchFrames, includeRoot);
 
                 if (foundNode != null)
                 {
@@ -338,6 +340,7 @@ namespace MapiInspector
 
             if (searchFrames)
             {
+                includeRoot = true; // Now that we're searching new frames, always include the root node in our search
                 var currentSession = Inspector.session;
                 while (currentSession != null)
                 {
@@ -348,8 +351,8 @@ namespace MapiInspector
                     var node = BaseStructure.AddBlock(parseResult, false);
                     rootNode.Nodes.Add(node);
                     var foundMatch = searchUp
-                        ? FindPrevNode(rootNode.Nodes, node, searchText, true, true)
-                        : FindNextNode(rootNode.Nodes, node, searchText, true, true);
+                        ? FindPrevNode(rootNode.Nodes, node, searchText, true, includeRoot)
+                        : FindNextNode(rootNode.Nodes, node, searchText, true, includeRoot);
                     if (foundMatch != null)
                     {
                         FiddlerApplication.UI.SelectSessionsMatchingCriteria(s => s.id == nextSession.id);

--- a/MAPIInspector/Source/Parsers/MSOXCFOLD/rops/RopCopyFolderResponse.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCFOLD/rops/RopCopyFolderResponse.cs
@@ -41,7 +41,6 @@ namespace MAPIInspector.Parsers
             RopId = ParseT<RopIdType>();
             SourceHandleIndex = ParseT<byte>();
             ReturnValue = ParseT<ErrorCodes>();
-            //ParseT<ErrorCodes>();
             if ((AdditionalErrorCodes)ReturnValue.Data == AdditionalErrorCodes.NullDestinationObject)
             {
                 DestHandleIndex = ParseT<uint>();

--- a/MAPIInspector/Source/Parsers/MSOXCFOLD/rops/RopCreateFolderResponse.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCFOLD/rops/RopCreateFolderResponse.cs
@@ -67,7 +67,6 @@ namespace MAPIInspector.Parsers
             RopId = ParseT<RopIdType>();
             OutputHandleIndex = ParseT<byte>();
             ReturnValue = ParseT<ErrorCodes>();
-
             if (ReturnValue == ErrorCodes.Success)
             {
                 FolderId = Parse<FolderID>();

--- a/MAPIInspector/Source/Parsers/MSOXCROPS/rops/RopTransportSendResponse.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCROPS/rops/RopTransportSendResponse.cs
@@ -4,8 +4,9 @@ using System.Collections.Generic;
 namespace MAPIInspector.Parsers
 {
     /// <summary>
-    /// [MS-OXCROPS] 2.2.7.6 RopTransportSend
-    /// A class indicates the RopTransportSend ROP Response Buffer.
+    /// [MS-OXCROPS] 2.2.7.6.2 RopTransportSend ROP Success Response Buffer
+    /// [MS-OXCROPS] 2.2.7.6.3 RopTransportSend ROP Failure Response Buffer
+    /// /// A class indicates the RopTransportSend ROP Response Buffer.
     /// </summary>
     public class RopTransportSendResponse : Block
     {
@@ -46,8 +47,7 @@ namespace MAPIInspector.Parsers
         {
             RopId = ParseT<RopIdType>();
             InputHandleIndex = ParseT<byte>();
-            this.AddError(ReturnValue, "ReturnValue");
-
+            //ReturnValue = ParseT<ErrorCodes>();
             if (ReturnValue == ErrorCodes.Success)
             {
                 NoPropertiesReturned = ParseT<byte>();

--- a/MAPIInspector/Source/Parsers/MSOXCROPS/rops/RopTransportSendResponse.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCROPS/rops/RopTransportSendResponse.cs
@@ -47,7 +47,7 @@ namespace MAPIInspector.Parsers
         {
             RopId = ParseT<RopIdType>();
             InputHandleIndex = ParseT<byte>();
-            //ReturnValue = ParseT<ErrorCodes>();
+            ReturnValue = ParseT<ErrorCodes>();
             if (ReturnValue == ErrorCodes.Success)
             {
                 NoPropertiesReturned = ParseT<byte>();


### PR DESCRIPTION
This pull request improves search functionality and code clarity in the MAPIInspector project, especially around tree node searching and error handling in various response parsers. The most significant changes are enhancements to the search logic, making searches more intuitive and robust, and updates to error handling and documentation for ROP response classes.

### Search Functionality Improvements

* Updated the tree node search logic in `MAPIControl.Events.cs` to allow optionally including the currently selected node in search results, improving usability for both upward and downward searches. This involved adding a `matchStartNode` parameter to `FindNextNode` and `FindPrevNode`, and adjusting how searches start and wrap around the node list. [[1]](diffhunk://#diff-0f83b29308b31d7928457a4194349ce57169f64017f68d39f1d0e0ae040b9e21R317-R330) [[2]](diffhunk://#diff-0f83b29308b31d7928457a4194349ce57169f64017f68d39f1d0e0ae040b9e21R343) [[3]](diffhunk://#diff-0f83b29308b31d7928457a4194349ce57169f64017f68d39f1d0e0ae040b9e21L351-R355) [[4]](diffhunk://#diff-0f83b29308b31d7928457a4194349ce57169f64017f68d39f1d0e0ae040b9e21L368-R448)
* Refactored the `FlattenNodes` helper method to return a list instead of an enumerable, enabling more efficient and flexible node traversal for search operations.

### Error Handling and Parser Updates

* Corrected the order of parsing and error handling in `RopTransportSendResponse` by parsing the `ReturnValue` before using it, and updated the class documentation to clarify the distinction between success and failure response buffers. [[1]](diffhunk://#diff-f49a005e4e93214dd4fab209442d5149f30e85cc6e7e3340a2c5cb8b145958caL7-R9) [[2]](diffhunk://#diff-f49a005e4e93214dd4fab209442d5149f30e85cc6e7e3340a2c5cb8b145958caL49-R50)
* Minor cleanup in folder response parsers (`RopCopyFolderResponse`, `RopCreateFolderResponse`) to remove commented-out code and unnecessary blank lines, making the codebase easier to read and maintain. [[1]](diffhunk://#diff-7ed84bf364925cfe14d91411c30891247f0e6d73a45f09d2112d5f0a6af00b59L44) [[2]](diffhunk://#diff-1c554e218250d0426a62410d143925c010af098820443a7184d33d8650360784L70)

### Label and UI Improvements

* Changed the label in `BlockJunk` from "Exceptions found in this block" to "Extra data found in this block" for more accurate representation of the block's contents.