### PR TITLE
fix missing text

### DIFF
--- a/MAPIInspector/Source/Parsers/BaseStructure.cs
+++ b/MAPIInspector/Source/Parsers/BaseStructure.cs
@@ -52,7 +52,11 @@ namespace MAPIInspector.Parsers
         private static TreeNode AddBlock(Block block, int blockRootOffset, bool debug)
         {
             // Clean up embedded null characters in the block text for display purposes
-            var text = block.Text.Replace("\0", "\\0");
+            var text = block.Text?.Replace("\0", "\\0");
+            if (text == null)
+            {
+                text = $"Exception: Missing Text property for {block.GetType()}";
+            }
             const int maxNodeLength = 100;
             // Truncate the text if it exceeds 100 characters for display purposes
             if (text.Length > maxNodeLength)

--- a/MAPIInspector/Source/Parsers/MSOXCDATA/2.11 Property Values/PtypServerIdStruct.cs
+++ b/MAPIInspector/Source/Parsers/MSOXCDATA/2.11 Property Values/PtypServerIdStruct.cs
@@ -52,6 +52,7 @@ namespace MAPIInspector.Parsers
 
         protected override void ParseBlocks()
         {
+            Text = "PtypServerId";
             AddChildBlockT(Ours, "Ours");
             AddLabeledChild(FolderID, "FolderID");
             AddLabeledChild(MessageID, "MessageID");


### PR DESCRIPTION
This pull request improves the robustness and clarity of the block parsing and display logic in the MAPIInspector tool. The main changes address potential null reference issues and enhance the labeling of parsed property values.

**Error handling and robustness improvements:**

- Updated `AddBlock` in `BaseStructure.cs` to safely handle cases where `block.Text` is null, providing a clear exception message instead of causing a crash.

**Labeling and parsing enhancements:**

- Set the `Text` property to `"PtypServerId"` in the `ParseBlocks` method of `PtypServerIdStruct.cs` to ensure proper labeling of this block in the UI.